### PR TITLE
Fix participants YAML syntax by wrapping markdown links in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ participants:
 ---
 date: 2025-08-05
 participants:
-  - [[Bob Smith]]
-  - [[Alice Sanders]]
+  - "[[Bob Smith]]"
+  - "[[Alice Sanders]]"
 description: In this conversation Bob and Alice discuss their weekend plans and upcoming project deadlines.
 tags:
   - aim
@@ -222,8 +222,8 @@ The converter automatically includes YAML frontmatter when a date can be extract
 ---
 date: 2004-05-18
 participants:
-  - [[Alice Sanders]]
-  - [[Bob Smith]]
+  - "[[Alice Sanders]]"
+  - "[[Bob Smith]]"
 description: In this conversation Alice and Bob catch up on recent events, discuss their weekend plans, and share updates about their work projects.
 tags:
   - aim

--- a/src/markdown_converter.py
+++ b/src/markdown_converter.py
@@ -29,7 +29,7 @@ class MarkdownConverter:
             if participants:
                 output.append("participants:")
                 for participant in participants:
-                    output.append(f"  - {participant}")
+                    output.append(f"  - \"{participant}\"")
             
             if description:
                 output.append(f"description: {description}")

--- a/tests/test_participants.py
+++ b/tests/test_participants.py
@@ -293,8 +293,8 @@ participants:
             
             # Should contain participants in frontmatter
             self.assertIn("participants:", result)
-            self.assertIn("- [[Bob Smith]]", result)
-            self.assertIn("- [[Alice Sanders]]", result)
+            self.assertIn("- \"[[Bob Smith]]\"", result)
+            self.assertIn("- \"[[Alice Sanders]]\"", result)
             
             # Should contain human-readable names in description
             self.assertIn("Bob and Alice exchange", result)


### PR DESCRIPTION
## Summary
- Fix participants YAML syntax to wrap markdown links in quotes for Obsidian compatibility
- Update test expectations and documentation to match quoted format

## Problem
Obsidian was unable to properly link participants in YAML frontmatter because the markdown links were not quoted. The syntax was:
```yaml
participants:
  - [[Alice Sanders]]
  - [[Bob Smith]]
```

## Solution
Updated the markdown converter to wrap participant markdown links in double quotes:
```yaml
participants:
  - "[[Alice Sanders]]"
  - "[[Bob Smith]]"
```

## Changes Made
- Modified `MarkdownConverter` to add quotes around participant entries
- Updated test assertions to expect quoted format
- Fixed README examples to show correct syntax
- All 106 tests passing

## Test Plan
- [x] All existing tests pass
- [x] Participant YAML output includes proper quotes
- [x] README examples show correct syntax

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)